### PR TITLE
Delete IP address and keypair on delete of Server or Client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -375,6 +375,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "diesel_migrations"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf3cde8413353dc7f5d72fa8ce0b99a560a359d2c5ef1e5817ca731cd9008f4c"
+dependencies = [
+ "migrations_internals",
+ "migrations_macros",
+]
+
+[[package]]
 name = "digest"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -817,6 +827,27 @@ name = "memchr"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
+
+[[package]]
+name = "migrations_internals"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b4fc84e4af020b837029e017966f86a1c2d5e83e64b589963d5047525995860"
+dependencies = [
+ "diesel",
+]
+
+[[package]]
+name = "migrations_macros"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9753f12909fd8d923f75ae5c3258cae1ed3c8ec052e1b38c93c21a6d157f789c"
+dependencies = [
+ "migrations_internals",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "mime"
@@ -2061,6 +2092,7 @@ dependencies = [
  "async-graphql",
  "async-graphql-rocket",
  "diesel",
+ "diesel_migrations",
  "dotenv",
  "handlebars",
  "ipaddress",

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -8,6 +8,7 @@ async-graphql = "3.0"
 async-graphql-rocket = "3.0"
 rocket = "0.5.0-rc.1"
 diesel = { version = "1.4", features = ["postgres", "r2d2"] }
+diesel_migrations = "1.4"
 dotenv = "0.15.0"
 ipaddress = "0.1"
 handlebars = "4.2"

--- a/api/migrations/2022-01-13-114035_fix_delete_cascade/down.sql
+++ b/api/migrations/2022-01-13-114035_fix_delete_cascade/down.sql
@@ -1,0 +1,8 @@
+ALTER TABLE clients ALTER COLUMN dns_server_id TYPE SERIAL;
+ALTER TABLE clients ALTER COLUMN keypair_id TYPE SERIAL;
+ALTER TABLE clients ALTER COLUMN vpn_ip_address_id TYPE SERIAL;
+
+ALTER TABLE servers ALTER COLUMN keypair_id TYPE SERIAL;
+ALTER TABLE servers ALTER COLUMN vpn_ip_address_id TYPE SERIAL;
+
+ALTER TABLE vpn_ip_addresses ALTER COLUMN vpn_network_id TYPE SERIAL;

--- a/api/migrations/2022-01-13-114035_fix_delete_cascade/up.sql
+++ b/api/migrations/2022-01-13-114035_fix_delete_cascade/up.sql
@@ -1,0 +1,23 @@
+ALTER TABLE clients ALTER COLUMN dns_server_id DROP DEFAULT;
+ALTER TABLE clients ALTER COLUMN dns_server_id TYPE INT;
+DROP SEQUENCE clients_dns_server_id_seq;
+
+ALTER TABLE clients ALTER COLUMN keypair_id DROP DEFAULT;
+ALTER TABLE clients ALTER COLUMN keypair_id TYPE INT;
+DROP SEQUENCE clients_keypair_id_seq;
+
+ALTER TABLE clients ALTER COLUMN vpn_ip_address_id DROP DEFAULT;
+ALTER TABLE clients ALTER COLUMN vpn_ip_address_id TYPE INT;
+DROP SEQUENCE clients_vpn_ip_address_id_seq;
+
+ALTER TABLE servers ALTER COLUMN keypair_id DROP DEFAULT;
+ALTER TABLE servers ALTER COLUMN keypair_id TYPE INT;
+DROP SEQUENCE servers_keypair_id_seq;
+
+ALTER TABLE servers ALTER COLUMN vpn_ip_address_id DROP DEFAULT;
+ALTER TABLE servers ALTER COLUMN vpn_ip_address_id TYPE INT;
+DROP SEQUENCE servers_vpn_ip_address_id_seq;
+
+ALTER TABLE vpn_ip_addresses ALTER COLUMN vpn_network_id DROP DEFAULT;
+ALTER TABLE vpn_ip_addresses ALTER COLUMN vpn_network_id TYPE INT;
+DROP SEQUENCE vpn_ip_addresses_vpn_network_id_seq;

--- a/api/src/main.rs
+++ b/api/src/main.rs
@@ -54,8 +54,7 @@ fn rocket() -> _ {
     let connection = db_connection_pool
         .get()
         .expect("Recieved no connection from pool");
-    embedded_migrations::run(&connection)
-        .expect("Migrations could not be applied successfully");
+    embedded_migrations::run(&connection).expect("Migrations could not be applied successfully");
 
     rocket::build()
         .manage(create_schema(db_connection_pool))

--- a/api/src/main.rs
+++ b/api/src/main.rs
@@ -11,6 +11,8 @@ mod validate;
 
 #[macro_use]
 extern crate diesel;
+#[macro_use]
+extern crate diesel_migrations;
 mod schema;
 
 /// Creates a new pool for connecting to the database
@@ -43,11 +45,20 @@ async fn graphql_request(
     request.execute(schema).await
 }
 
+embed_migrations!();
+
 /// Entrypoint of this binary crate that initializes the webserver
 #[rocket::launch]
 fn rocket() -> _ {
+    let db_connection_pool = establish_connection();
+    let connection = db_connection_pool
+        .get()
+        .expect("Recieved no connection from pool");
+    embedded_migrations::run(&connection)
+        .expect("Migrations could not be applied successfully");
+
     rocket::build()
-        .manage(create_schema(establish_connection()))
+        .manage(create_schema(db_connection_pool))
         .mount(
             "/",
             routes![graphql_query, graphql_request, graphql_playground],

--- a/api/src/models/client.rs
+++ b/api/src/models/client.rs
@@ -215,6 +215,8 @@ impl Client {
     /// * `id` - The id of the client that should be deleted
     pub fn delete(connection: &SingleConnection, id: i32) -> Result<bool> {
         let client = Client::get_by_id(connection, id)?;
+        VpnIpAddress::delete(connection, client.vpn_ip_address_id)?;
+        Keypair::delete(connection, client.keypair_id)?;
         diesel::delete(&client)
             .execute(connection)
             .map(|_| true)

--- a/api/src/models/keypair.rs
+++ b/api/src/models/keypair.rs
@@ -20,7 +20,7 @@ pub struct NewKeypair<'a> {
 }
 
 /// A Keypair that is used by a `Client` or `Server`
-#[derive(SimpleObject, Queryable, Debug)]
+#[derive(Debug, SimpleObject, Queryable, Identifiable)]
 pub struct Keypair {
     pub id: i32,
     pub public_key: String,
@@ -54,6 +54,22 @@ impl Keypair {
             .values(&new_keypair)
             .get_result(connection)
             .expect("Error saving generated keypair")
+    }
+
+    /// Deletes a [`Keypair`] from the database
+    ///
+    /// # Arguments
+    /// * `connection` - A connection to the database
+    /// * `keypair_id` - The id of the [`Keypair`] that should be deleted
+    ///
+    /// # Returns
+    /// Returns true if the operation was successful or an error
+    pub fn delete(connection: &SingleConnection, keypair_id: i32) -> Result<bool> {
+        let keypair = Keypair::get_by_id(connection, keypair_id)?;
+        diesel::delete(&keypair)
+            .execute(connection)
+            .map(|_| true)
+            .map_err(Error::from)
     }
 
     /// Generates a new [`Keypair`] and returns it

--- a/api/src/models/server.rs
+++ b/api/src/models/server.rs
@@ -252,6 +252,8 @@ impl Server {
     /// Deletes the [`Server`] with the given id from the database
     pub fn delete(connection: &SingleConnection, server_id: i32) -> Result<bool> {
         let server = Self::get_by_id(connection, server_id)?;
+        VpnIpAddress::delete(connection, server.vpn_ip_address_id)?;
+        Keypair::delete(connection, server.keypair_id)?;
         diesel::delete(&server)
             .execute(connection)
             .map(|_| true)

--- a/api/src/models/vpn_ip_address.rs
+++ b/api/src/models/vpn_ip_address.rs
@@ -53,10 +53,7 @@ impl VpnIpAddress {
     ///
     /// # Returns
     /// Returns true if the operation was successful or an error
-    pub fn delete<'a>(
-        connection: &SingleConnection,
-        vpn_ip_address_id: i32
-    ) -> Result<bool> {
+    pub fn delete<'a>(connection: &SingleConnection, vpn_ip_address_id: i32) -> Result<bool> {
         let vpn_ip = Self::get_by_id(connection, vpn_ip_address_id);
         diesel::delete(&vpn_ip)
             .execute(connection)

--- a/api/src/models/vpn_ip_address.rs
+++ b/api/src/models/vpn_ip_address.rs
@@ -11,7 +11,8 @@ pub struct NewVpnIpAddress<'a> {
 }
 
 /// A `VpnIpAddress` represents a unique ip address that is associated with a `VpnNetwork`
-#[derive(Debug, Queryable)]
+#[derive(Debug, Queryable, Identifiable)]
+#[table_name = "vpn_ip_addresses"]
 pub struct VpnIpAddress {
     pub id: i32,
     pub vpn_network_id: i32,
@@ -41,6 +42,25 @@ impl VpnIpAddress {
         diesel::insert_into(vpn_ip_addresses::table)
             .values(&new_ip)
             .get_result(connection)
+            .map_err(Error::from)
+    }
+
+    /// Deletes a [`VpnIpAddress`] from the database
+    ///
+    /// # Arguments
+    /// * `connection` - A connection to the database
+    /// * `vpn_ip_address_id` - The id of the [`VpnIpAddress`] that should be deleted
+    ///
+    /// # Returns
+    /// Returns true if the operation was successful or an error
+    pub fn delete<'a>(
+        connection: &SingleConnection,
+        vpn_ip_address_id: i32
+    ) -> Result<bool> {
+        let vpn_ip = Self::get_by_id(connection, vpn_ip_address_id);
+        diesel::delete(&vpn_ip)
+            .execute(connection)
+            .map(|_| true)
             .map_err(Error::from)
     }
 


### PR DESCRIPTION
* Change type of reference columns to INT instead of SERIAL. Because of
  this also delete the unused sequences.
* Delete Keypair and VpnIPAddress before deleting the Server or Client

Closes #18 