### PR TITLE
Fix sequence table name for vpn_ip_addresses

### DIFF
--- a/api/migrations/2022-01-13-155046_fix_seq_name_vpn_ip_addresses/down.sql
+++ b/api/migrations/2022-01-13-155046_fix_seq_name_vpn_ip_addresses/down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE vpn_ip_addresses_id_seq RENAME TO vpn_ip_addressses_id_seq;

--- a/api/migrations/2022-01-13-155046_fix_seq_name_vpn_ip_addresses/up.sql
+++ b/api/migrations/2022-01-13-155046_fix_seq_name_vpn_ip_addresses/up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE vpn_ip_addressses_id_seq RENAME TO vpn_ip_addresses_id_seq;


### PR DESCRIPTION
The vpn_ip_addresses table had a typo. As it was fixed the sequence
table for this table was not renamed too.