### PR TITLE
Validate if the keypair is already used before creating a Client or Server

### DIFF
--- a/api/src/models.rs
+++ b/api/src/models.rs
@@ -14,10 +14,12 @@ use dns_server::{DnsServer, InputDnsServer};
 mod vpn_network;
 use vpn_network::{InputVpnNetwork, VpnNetwork};
 mod client;
-use client::{Client, InputClient, QueryableClient};
+use client::{InputClient, QueryableClient};
+pub use client::Client;
 mod server;
 mod vpn_ip_address;
-use server::{InputServer, QueryableServer, Server};
+use server::{InputServer, QueryableServer};
+pub use server::Server;
 
 /// Represents the schema that is created by [`create_schema()`]
 pub type GrahpQLSchema = Schema<QueryRoot, Mutation, EmptySubscription>;

--- a/api/src/models.rs
+++ b/api/src/models.rs
@@ -14,12 +14,12 @@ use dns_server::{DnsServer, InputDnsServer};
 mod vpn_network;
 use vpn_network::{InputVpnNetwork, VpnNetwork};
 mod client;
-use client::{InputClient, QueryableClient};
 pub use client::Client;
+use client::{InputClient, QueryableClient};
 mod server;
 mod vpn_ip_address;
-use server::{InputServer, QueryableServer};
 pub use server::Server;
+use server::{InputServer, QueryableServer};
 
 /// Represents the schema that is created by [`create_schema()`]
 pub type GrahpQLSchema = Schema<QueryRoot, Mutation, EmptySubscription>;

--- a/api/src/models/client.rs
+++ b/api/src/models/client.rs
@@ -253,7 +253,7 @@ impl Client {
             return Err(Error::new(format!(
                 "Keypair with id {} is already used!",
                 client.keypair_id
-            )))
+            )));
         }
 
         // Check if vpn network exists

--- a/api/src/models/client.rs
+++ b/api/src/models/client.rs
@@ -6,7 +6,7 @@ use handlebars::Handlebars;
 use super::vpn_ip_address::VpnIpAddress;
 use super::*;
 use crate::schema::{clients, vpn_ip_addresses};
-use crate::validate::is_ip_in_network;
+use crate::validate::{is_ip_in_network, is_keypair_used};
 
 const CLIENT_CONFIG: &str = r#"[Interface]
 PrivateKey = {{clientPrivateKey}}
@@ -247,6 +247,13 @@ impl Client {
                 "Keypair with id {} not found for client",
                 client.keypair_id
             )));
+        }
+        // Check if keypair is already used
+        if is_keypair_used(connection, client.keypair_id) {
+            return Err(Error::new(format!(
+                "Keypair with id {} is already used!",
+                client.keypair_id
+            )))
         }
 
         // Check if vpn network exists

--- a/api/src/models/server.rs
+++ b/api/src/models/server.rs
@@ -219,7 +219,7 @@ impl Server {
             return Err(Error::new(format!(
                 "Keypair with id {} is already used!",
                 server.keypair_id
-            )))
+            )));
         }
 
         // Check if vpn network exists

--- a/api/src/models/server.rs
+++ b/api/src/models/server.rs
@@ -4,7 +4,7 @@ use handlebars::Handlebars;
 use super::vpn_ip_address::VpnIpAddress;
 use super::*;
 use crate::schema::servers;
-use crate::validate::is_ip_in_network;
+use crate::validate::{is_ip_in_network, is_keypair_used};
 
 const SERVER_CONFIG: &str = r#"# Server configuration
 [Interface]
@@ -213,6 +213,13 @@ impl Server {
                 "Keypair with id {} not found for client",
                 server.keypair_id
             )));
+        }
+        // Check if keypair is already used
+        if is_keypair_used(connection, server.keypair_id) {
+            return Err(Error::new(format!(
+                "Keypair with id {} is already used!",
+                server.keypair_id
+            )))
         }
 
         // Check if vpn network exists

--- a/api/src/validate.rs
+++ b/api/src/validate.rs
@@ -2,10 +2,31 @@
 use ipaddress::IPAddress;
 use std::net::Ipv4Addr;
 
+use crate::models::{Client, Server, SingleConnection};
+
 /// Validates if an ip address is in the given network or not
+///
+/// # Arguments
+/// * `ip_network` - The ip network in that the ip addresss should be in
+/// * `subnetmask` - The subnetmask of the `ip_network` in CIDR format
+/// * `ip_address` - The ip address that should be validated
 pub fn is_ip_in_network(ip_network: Ipv4Addr, subnetmask: i32, ip_address: Ipv4Addr) -> bool {
     let ip_address = IPAddress::parse(format!("{}/{}", ip_address, subnetmask)).unwrap();
     ip_address.network().to_s().parse::<Ipv4Addr>().unwrap() == ip_network
+}
+
+/// Verifies if the given id of a `Keypair` is already used by another `Client` or `Server`
+///
+/// # Arguments
+/// * `connection` - A connection to the database
+/// * `keypair_id` - The id of the `Keypair` that should be checked
+pub fn is_keypair_used(connection: &SingleConnection, keypair_id: i32) -> bool {
+    let mut used_keypairs =
+        Client::get_keypair_ids(connection).expect("Error while querying the database");
+    used_keypairs
+        .extend(Server::get_keypair_ids(connection).expect("Error while querying the database"));
+
+    used_keypairs.contains(&keypair_id)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
A keypair must not be used twice in the same setup. This breaks parts of
the setup.

Closes #34 